### PR TITLE
Remove migration queries logs in tests

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,6 +3,7 @@ use std::env;
 use config::{Config, File, FileFormat};
 use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use sqlx::ConnectOptions;
 
 #[derive(serde::Deserialize)]
 pub struct Settings {
@@ -44,7 +45,9 @@ impl DatabaseSettings {
     }
 
     pub fn with_db(&self) -> PgConnectOptions {
-        self.without_db().database(&self.database_name)
+        let mut options = self.without_db().database(&self.database_name);
+        options.log_statements(tracing::log::LevelFilter::Trace);
+        options
     }
 }
 


### PR DESCRIPTION
Removes the logs regarding the database creation migration schemas, they were long and getting repeated for each test.